### PR TITLE
Add host permissions for hianime.to

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,6 +6,7 @@
   "permissions": ["storage"],
   "host_permissions": [
     "https://hianimez.to/*",
+    "https://hianime.to/*",
     "https://*.megacloud.tv/embed*",
     "https://*.megacloud.blog/embed*",
     "https://animekai.to/*"
@@ -14,6 +15,7 @@
     {
       "matches": [
         "https://hianimez.to/*",
+        "https://hianime.to/*",
         "https://*.megacloud.tv/embed*",
         "https://*.megacloud.blog/embed*",
         "https://animekai.to/*"


### PR DESCRIPTION
## Summary
- support the domain `hianime.to` by adding it to manifest host permissions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6857b196a9c883328a94ac63dddaaa6d