### PR TITLE
Add gap between navigation buttons

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -124,7 +124,7 @@ const unsafeWindow = window;
         #migaku-controller.minimized .controller-content, #migaku-controller.minimized .log-area, #migaku-controller.minimized .controller-nav, #migaku-controller.minimized #migaku-error-bar, #migaku-controller.minimized h3 { display: none; }
         #migaku-toggle-btn { position: absolute; top: 12px; right: 12px; background: none; border: none; color: inherit; font-size: 18px; cursor: pointer; padding: 0; margin: 0; width: 20px; height: 20px; line-height: 20px; text-align: center; z-index: 1; }
         #migaku-controller h3 { padding-right: 35px; margin-top: 0; margin-bottom: 10px; font-size: 18px; color: #555; }
-        .controller-nav { display: flex; justify-content: space-around; margin-bottom: 15px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+        .controller-nav { display: flex; justify-content: space-around; margin-bottom: 15px; border-bottom: 1px solid #eee; padding-bottom: 8px; gap: 4px; }
         #migaku-controller.dark-mode .controller-nav { border-bottom-color: #555; }
         .controller-nav button { background: none; border: none; color: #555; cursor: pointer; font-size: 13px; padding: 5px 6px; transition: color 0.2s ease, border-bottom-color 0.2s ease; flex-grow: 1; text-align: center; white-space: nowrap; }
         .controller-nav button:hover { color: #000; }


### PR DESCRIPTION
## Summary
- space out the page navigation buttons so they aren't touching

## Testing
- `node --check extension/content.js`

------
https://chatgpt.com/codex/tasks/task_e_6857b4ffca848332af375927fe43439f